### PR TITLE
Remove Module Header Comments

### DIFF
--- a/src/php/admin/remove-dashboard-widgets.php
+++ b/src/php/admin/remove-dashboard-widgets.php
@@ -1,10 +1,5 @@
 <?php
-/**
- * Module Name: Zynith SEO - Remove Dashboard Widgets
- * Description: Removes all default WordPress dashboard widgets for a cleaner dashboard.
- * Version:     1.1.2
- * Author:      Zynith SEO
-*/
+
 defined('ABSPATH') or exit;
 
 // Remove default WordPress dashboard widgets

--- a/src/php/content-management/add-alt-text.php
+++ b/src/php/content-management/add-alt-text.php
@@ -1,10 +1,5 @@
 <?php
-/**
- * Module Name: Zynith SEO - Add Alt Text to Media
- * Description: Zynith SEO module to automatically set the ALT text of images based on the file name.
- * Version:     1.0.0
- * Author:      Zynith SEO
-*/
+
 function zynith_seo_add_alt_text($post_ID) {
     
     // Only proceed if this is indeed an image.

--- a/src/php/content-management/admin-title-search.php
+++ b/src/php/content-management/admin-title-search.php
@@ -1,10 +1,4 @@
 <?php
-/*
-Plugin Name: Zynith SEO - Admin Search by Title Only
-Description: Limits the admin search to page titles only in the Pages section.
-Version: 1.0.1
-Author: Zynith SEO
-*/
 
 if (!defined('ABSPATH')) exit;
 

--- a/src/php/content-management/breadcrumb-editor.php
+++ b/src/php/content-management/breadcrumb-editor.php
@@ -1,10 +1,4 @@
 <?php
-/*
-Plugin Name: ZYNITH SEO Breadcrumbs
-Description: A breadcrumbs module for ZYNITH SEO that includes schema injection, customization options, and optional CSS class.
-Version: 1.3.1
-Author: ZYNITH SEO
-*/
 
 if (!defined('ABSPATH')) exit;
 

--- a/src/php/content-management/custom-data-sanitization.php
+++ b/src/php/content-management/custom-data-sanitization.php
@@ -1,10 +1,4 @@
 <?php
-/*
-Plugin Name:    Zynith SEO - Custom Data Sanitization
-Description:    Safely sanitizes custom placeholders (e.g., %%title%%, %%date%%) in SEO meta fields.
-Version:        0.0.0
-Author:         Zynith SEO
-*/
 
 defined('ABSPATH') or exit;
 

--- a/src/php/content-management/custom-post-type.php
+++ b/src/php/content-management/custom-post-type.php
@@ -1,10 +1,4 @@
 <?php
-/*
-Module Name: ZYNITH SEO Custom Post Types
-Description: This module allows users to create and manage custom post types (CPTs) natively within ZYNITH SEO.
-Author: ZYNITH SEO
-Version: 1.6
-*/
 
 if (!defined('ABSPATH')) {
     exit;

--- a/src/php/content-management/dynamic-placeholders.php
+++ b/src/php/content-management/dynamic-placeholders.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Plugin Name:    Zynith SEO - Dynamic Placeholders
- * Description:    Replaces custom placeholders (e.g. %%title%%, %%date%%, etc.) in post content.
- * Version:        0.0.2
- * Author:         Zynith SEO
- */
 
 defined('ABSPATH') or exit;
 

--- a/src/php/content-management/toc-editor.php
+++ b/src/php/content-management/toc-editor.php
@@ -1,10 +1,5 @@
 <?php
-/**
- * Module Name: Zynith SEO - Table of Contents Editor
- * Description: A Table of Contents plugin for Zynith SEO with customizable options and dynamic heading nesting.
- * Version:     2.3.3
- * Author:      Zynith SEO
-*/
+
 defined('ABSPATH') or exit;
 
 // Add settings page under the Zynith SEO menu

--- a/src/php/dashboard/zynith-dashboard-information-widget.php
+++ b/src/php/dashboard/zynith-dashboard-information-widget.php
@@ -1,10 +1,5 @@
 <?php
-/**
- * Module Name: Zynith SEO - Dashboard Update Notes Widget
- * Description: A dashboard widget displaying update information for Zynith SEO with integration into the main Zynith SEO plugin.
- * Version:     1.2.9
- * Author:      Zynith SEO
- */
+
 defined('ABSPATH') or exit;
 
 // Save the license key via POST request.

--- a/src/php/dashboard/zynith-meta-copy-widget.php
+++ b/src/php/dashboard/zynith-meta-copy-widget.php
@@ -1,10 +1,5 @@
 <?php
-/**
- * Module Name: Zynith SEO - Meta Copy and Export Widget
- * Description: A dashboard widget for copying meta information from Yoast, RankMath, Zynith <9.0, including noindex and nofollow settings, and exporting Zynith meta data to CSV.
- * Version:     1.2.5
- * Author:      Zynith SEO
- */
+
 defined('ABSPATH') or exit;
 
 // Display function for the Meta Copy and Export Widget

--- a/src/php/media/enable-svg-upload.php
+++ b/src/php/media/enable-svg-upload.php
@@ -1,10 +1,4 @@
 <?php
-/*
-Plugin Name: ZYNITH SEO - SVG Upload Support
-Description: Allows SVG files to be uploaded to the WordPress media library by default for ZYNITH SEO.
-Version: 1.0
-Author: ZYNITH SEO
-*/
 
 // Exit if accessed directly
 if ( !defined( 'ABSPATH' ) ) {

--- a/src/php/performance/deferment-manager.php
+++ b/src/php/performance/deferment-manager.php
@@ -1,13 +1,6 @@
 <?php
-/*
-Plugin Name: Zynith SEO Deferment Manager
-Description: Manage JavaScript deferment, lazy loading, critical preloading, and dynamic hero image optimization for improved performance.
-Version: 3.3.1
-Author: Zynith SEO
-*/
+
 if (!defined('ABSPATH')) exit;
-
-
 
 // Add the Deferment Manager submenu
 function zynith_seo_deferment_manager_menu() {

--- a/src/php/performance/disable-gutenberg.php
+++ b/src/php/performance/disable-gutenberg.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Module Name: Zynith SEO - Disable Gutenberg
- * Description: Disables Gutenberg editor and enables the Classic Editor for posts, pages, and custom post types. Removes Gutenberg styles from both the admin and the front end.
- * Version:     1.0.1
- * Author:      Zynith SEO
-*/
 
 // Disable Gutenberg for posts, pages, and custom post types
 add_filter('use_block_editor_for_post', '__return_false', 10);

--- a/src/php/performance/disable-rest-api.php
+++ b/src/php/performance/disable-rest-api.php
@@ -1,10 +1,4 @@
 <?php
-/*
-Plugin Name: ZYNITH SEO - Disable REST API
-Description: Disables the WordPress REST API for unauthenticated users to improve security.
-Version: 1.1
-Author: ZYNITH SEO
-*/
 
 // Disable REST API for unauthenticated users
 function zynith_seo_disable_rest_api( $access ) {

--- a/src/php/performance/disable-rss-feeds.php
+++ b/src/php/performance/disable-rss-feeds.php
@@ -1,10 +1,4 @@
 <?php
-/*
-Plugin Name: ZYNITH SEO RSS Disabler
-Description: Disables all RSS feeds and removes RSS feed links from the <head> section.
-Version: 1.0
-Author: ZYNITH SEO
-*/
 
 // Function to remove RSS feed links from the <head> section
 function zynith_seo_disable_rss_feed_links() {

--- a/src/php/performance/disable-wp-generator-tags.php
+++ b/src/php/performance/disable-wp-generator-tags.php
@@ -1,10 +1,4 @@
 <?php
-/*
-Plugin Name: ZYNITH SEO - Disable WordPress Generator Tag
-Description: Disables the WordPress generator meta tag from the HTML header to hide the WordPress version.
-Version: 1.0
-Author: ZYNITH SEO
-*/
 
 // Disable the WordPress generator tag (WordPress version number in the meta tag)
 function zynith_seo_disable_wp_generator_tag() {

--- a/src/php/performance/limit-autosave-intervals.php
+++ b/src/php/performance/limit-autosave-intervals.php
@@ -1,10 +1,4 @@
 <?php
-/*
-Plugin Name: ZYNITH SEO - Autosave Interval
-Description: Sets a custom autosave interval for posts/pages based on user settings from the ZYNITH SEO plugin.
-Version: 1.1
-Author: ZYNITH SEO
-*/
 
 // Exit if accessed directly
 if ( !defined( 'ABSPATH' ) ) {

--- a/src/php/performance/limit-revisions.php
+++ b/src/php/performance/limit-revisions.php
@@ -1,10 +1,5 @@
 <?php
-/**
- * Module Name: Zynith SEO - Revisions Limit
- * Description: Sets a limit on the number of revisions stored for posts/pages based on user settings from the ZYNITH SEO plugin.
- * Version:     1.0.1
- * Author:      Zynith SEO
-*/
+
 defined('ABSPATH') or exit;
 
 function zynith_seo_set_revision_limit() {

--- a/src/php/performance/wordpress-heartbeat-optimizer.php
+++ b/src/php/performance/wordpress-heartbeat-optimizer.php
@@ -1,10 +1,4 @@
 <?php
-/*
-Plugin Name: ZYNITH SEO Heartbeat Optimizer
-Description: Optimize the WordPress Heartbeat API frequency.
-Version: 1.0
-Author: ZYNITH SEO
-*/
 
 // Modify the Heartbeat API frequency
 function zynith_seo_optimize_heartbeat( $settings ) {

--- a/src/php/schema/automatic-schema-editor.php
+++ b/src/php/schema/automatic-schema-editor.php
@@ -1,10 +1,5 @@
 <?php
-/**
- * Module Name: Zynith SEO - Automatic Schema Editor
- * Description: Provides automated schema types for posts, pages, authors, date archives, about pages, contact pages, FAQ pages, and product schema with fields for company-specific details.
- * Version:     1.3.2
- * Author:      Zynith SEO
- */
+
 defined('ABSPATH') or exit;
 
 // Register Schema Settings Page in Zynith SEO Menu

--- a/src/php/schema/on-page-schema-editor.php
+++ b/src/php/schema/on-page-schema-editor.php
@@ -1,10 +1,5 @@
 <?php
-/*
- * Plugin Name: ZYNITH SEO - On-page Schema Editor Metabox
- * Description: Adds a schema editor metabox on pages, posts, and custom post types for quick on-page schema management.
- * Version: 1.0.3
- * Author: ZYNITH SEO
- */
+
 defined('ABSPATH') or exit;
 
 function zynith_seo_create_schema_table() {

--- a/src/php/seo-tools/404-monitor.php
+++ b/src/php/seo-tools/404-monitor.php
@@ -1,10 +1,4 @@
 <?php
-/*
-Plugin Name: ZYNITH SEO 404 Monitor
-Description: Logs 404 errors including URL, referrer, user agent, and timestamp, and displays them in the WordPress admin area. Allows creation and deletion of the 404 logs table, and deleting individual log entries.
-Version: 1.3.1
-Author: ZYNITH SEO
-*/
 
 if (!defined('ABSPATH')) exit;
 

--- a/src/php/seo-tools/bulk-index.php
+++ b/src/php/seo-tools/bulk-index.php
@@ -1,10 +1,5 @@
 <?php
-/**
- * Module Name: Zynith SEO - Bulk Index
- * Description: Adds “Mark as Noindex/Index” options to the bulk-edit dropdown in the All Posts/Pages list.
- * Version:     1.0.0
- * Author:      Zynith SEO
-*/
+
 defined('ABSPATH') or exit;
 
 // Add two new custom bulk actions to Posts & Pages

--- a/src/php/seo-tools/bulk-meta-editor.php
+++ b/src/php/seo-tools/bulk-meta-editor.php
@@ -1,10 +1,5 @@
 <?php
-/**
- * Module Name: Zynith SEO - Bulk Meta Editor
- * Description: Adds Meta Title and Meta Description fields to the Pages and Posts list in the WordPress admin and saves on blur. Also adds noindex/index functionality to the Bulk Actions WP drop-down box.
- * Version:     1.1.1
- * Author:      Zynith SEO
-*/
+
 defined('ABSPATH') or exit;
 
 function bulk_meta_editor_enqueue_scripts($hook) {

--- a/src/php/seo-tools/canonical-url-manager.php
+++ b/src/php/seo-tools/canonical-url-manager.php
@@ -1,10 +1,5 @@
 <?php
-/**
- * Module Name: Zynith SEO - Canonical URL Manager
- * Description: Adds a meta box for custom canonical URLs on pages, posts, and CPTs. Outputs the custom canonical URL in the `<head>` section and integrates with the sitemap.
- * Version:     1.0.1
- * Author:      Zynith SEO
- */
+
 defined('ABSPATH') or exit;
 
 // Add meta box for canonical URL

--- a/src/php/seo-tools/htaccess-file-editor.php
+++ b/src/php/seo-tools/htaccess-file-editor.php
@@ -1,10 +1,5 @@
 <?php
-/**
- * Module Name: Zynith SEO - .htaccess Editor
- * Description: This module adds an .htaccess Editor under the ZYNITH SEO menu, allowing you to edit the .htaccess file live using the WordPress admin UI. Only works if the server is Apache.
- * Version:     1.0.1
- * Author:      Zynith SEO
-*/
+
 defined('ABSPATH') or exit;
 
 // Check if the server is Apache before adding the menu

--- a/src/php/seo-tools/meta-editor.php
+++ b/src/php/seo-tools/meta-editor.php
@@ -1,10 +1,5 @@
 <?php
-/**
- * Module Name: Zynith SEO Meta Manager
- * Description: Adds a meta box for custom meta titles, descriptions, and OG tags. Outputs these meta tags in the <head> of the page. Supports any CPT, Categories, Tags, and Authors.
- * Version:     3.0.8
- * Author:      Zynith SEO
-*/
+
 defined('ABSPATH') or exit;
 
 // Render the meta box fields with WordPress styling

--- a/src/php/seo-tools/meta-robots-settings.php
+++ b/src/php/seo-tools/meta-robots-settings.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Module Name: Zynith SEO - Meta Robots Settings
- * Description: Adds a meta box for robots "No Index" and "No Follow" settings in posts, pages, and CPTs. Disables WordPress default robots tag, and adds a custom robots tag.
- * Version:     1.0.2
- * Author:      Zynith SEO
-*/
 
 // Disable WordPress default robots meta tag
 remove_action('wp_head', 'wp_robots', 1);

--- a/src/php/seo-tools/randomize-last-modified-date.php
+++ b/src/php/seo-tools/randomize-last-modified-date.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Plugin Name: Zynith SEO - Randomize Dates
- * Description: Allows users to randomize Last Modified or Published dates for posts, pages, CPTs, categories, tags, authors, and WooCommerce products.
- * Version: 1.1.0
- * Author: Zynith SEO
- */
 
 if (!defined('ABSPATH')) {
     exit;

--- a/src/php/seo-tools/redirect-manager.php
+++ b/src/php/seo-tools/redirect-manager.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Module Name: Zynith SEO - Redirect Manager
- * Version:     1.0.0
- * Author:      Zynith SEO
- */
 
 error_log('ZYNITH SEO DEBUG: Redirect Manager Loaded');
 

--- a/src/php/seo-tools/robots-txt-editor.php
+++ b/src/php/seo-tools/robots-txt-editor.php
@@ -1,10 +1,5 @@
 <?php
-/**
- * Module Name: Zynith SEO - Robots Text Editor
- * Description: This module adds a Robots Text Editor under the Zynith SEO menu, allowing you to edit the robots.txt file live using the WordPress admin UI.
- * Version:     1.0.2
- * Author:      Zynith SEO
-*/
+
 defined('ABSPATH') or exit;
 
 // Add Robots Editor Menu under ZYNITH SEO

--- a/src/php/seo-tools/script-manager.php
+++ b/src/php/seo-tools/script-manager.php
@@ -1,10 +1,5 @@
 <?php
-/**
- * Module Name: Zynith SEO - Script Manager
- * Description: Zynith SEO module to manage scripts on a per-page/post basis with the ability to create, retrieve, and delete scripts. Supports pages, posts, custom post types, categories, tags, and authors.
- * Version:     1.2.5
- * Author:      Zynith SEO
-*/
+
 defined('ABSPATH') or exit;
 
 // Add the Script Manager menu under Zynith SEO

--- a/src/php/seo-tools/search-and-replace.php
+++ b/src/php/seo-tools/search-and-replace.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Plugin Name: Zynith SEO - Search and Replace Submenu
- * Description: A sub-menu page for search and replace functionality across selected tables, including the option to delete tables.
- * Version: 1.0.0
- * Author: Zynith SEO
- */
 
 // Security check
 if (!defined('ABSPATH')) {

--- a/src/php/seo-tools/sitemap-generator.php
+++ b/src/php/seo-tools/sitemap-generator.php
@@ -1,9 +1,5 @@
 <?php
-/**
- * Module Name: Zynith SEO - Sitemap Generator
- * Version:     1.2.8
- * Author:      Zynith SEO
- */
+
 defined('ABSPATH') or exit;
 
 add_filter('wp_sitemaps_enabled', '__return_false');

--- a/src/php/ui/admin-bar-transition.php
+++ b/src/php/ui/admin-bar-transition.php
@@ -1,10 +1,4 @@
 <?php
-/*
-Plugin Name: ZYNITH SEO - Admin Bar Hover Transition (Screen Options and Help)
-Description: Adds a fade-in and fade-out transition effect to the WordPress admin bar's "Screen Options" and "Help" buttons. They will be 100% invisible by default and will fade in on hover.
-Version: 1.1.1
-Author: ZYNITH SEO
-*/
 
 if (!defined('ABSPATH')) exit;
 

--- a/src/php/ui/admin-dark-theme.php
+++ b/src/php/ui/admin-dark-theme.php
@@ -1,10 +1,4 @@
 <?php
-/*
-Plugin Name: ZYNITH SEO Darkmode UI
-Description: Provides a modern dark mode for the WordPress admin interface, disabling light mode when active.
-Version: 1.2
-Author: ZYNITH SEO
-*/
 
 // Enqueue dark mode CSS for the admin area with cache-busting
 function zynith_seo_enqueue_darkmode_ui() {

--- a/src/php/ui/admin-light-theme.php
+++ b/src/php/ui/admin-light-theme.php
@@ -1,10 +1,5 @@
 <?php
-/**
- * Module Name: Zynith SEO Light Theme
- * Description: Provides a modern light mode for the WordPress admin interface.
- * Version:     1.0.4
- * Author:      Zynith SEO
-*/
+
 defined('ABSPATH') or exit;
 
 function zynith_seo_enqueue_light_css() {

--- a/src/php/ui/custom-admin-url.php
+++ b/src/php/ui/custom-admin-url.php
@@ -1,10 +1,5 @@
 <?php
-/**
- * Module Name: Zynith SEO - Custom Admin URL
- * Description: Allows users to set a custom login URL and blocks default login paths by returning a 404 error.
- * Version:     1.0.0
- * Author:      Zynith SEO
- */
+
 defined('ABSPATH') or exit;
 
 // Add the custom login URL setting field to the main Zynith SEO settings page

--- a/src/php/ui/disable-admin-bar-resources.php
+++ b/src/php/ui/disable-admin-bar-resources.php
@@ -1,10 +1,4 @@
 <?php
-/*
-Plugin Name: ZYNITH SEO - Disable Admin Bar Links
-Description: Removes the WordPress admin bar links like About WordPress, Documentation, and others.
-Version: 1.0.1
-Author: ZYNITH SEO
-*/
 
 // Exit if accessed directly
 if (!defined('ABSPATH')) exit;

--- a/src/php/ui/disable-comments.php
+++ b/src/php/ui/disable-comments.php
@@ -1,10 +1,5 @@
 <?php
-/**
- * Module Name:    Zynith SEO - Disable Comments
- * Description:    This module disables comments across the entire site, removing comment forms and hiding existing comments.
- * Author:         Zynith SEO
- * Version:        1.0.1
-*/
+
 defined('ABSPATH') or exit;
 
 // Disable support for comments and trackbacks in post types

--- a/src/php/ui/footer-customizer.php
+++ b/src/php/ui/footer-customizer.php
@@ -1,10 +1,4 @@
 <?php
-/*
-Plugin Name: ZYNITH SEO - Admin Footer Customizer
-Description: Replaces the default WordPress footer message with a custom message.
-Version: 1.0.1
-Author: ZYNITH SEO
-*/
 
 // Exit if accessed directly
 if (!defined('ABSPATH')) exit;

--- a/src/php/ui/move-plugin-file-editor.php
+++ b/src/php/ui/move-plugin-file-editor.php
@@ -1,10 +1,4 @@
 <?php
-/*
-Module Name:    Move Plugin File Editor
-Description:    Moves the Plugin File Editor to the last option under the Plugins menu.
-Author:         ZYNITH SEO
-Version:        1.0.0
-*/
 
 if (!defined('ABSPATH')) exit;
 

--- a/src/php/ui/move-theme-file-editor.php
+++ b/src/php/ui/move-theme-file-editor.php
@@ -1,10 +1,4 @@
 <?php
-/*
-Module Name:    Move Theme File Editor
-Description:    Moves the Theme File Editor to the last option under the Appearance menu.
-Author:         ZYNITH SEO
-Version:        1.0.0
-*/
 
 if (!defined('ABSPATH')) exit;
 

--- a/src/php/updater/zynith-seo-updater.php
+++ b/src/php/updater/zynith-seo-updater.php
@@ -1,10 +1,5 @@
 <?php
-/**
- * Module Name: Zynith SEO - Plugin Updater
- * Description: Handles plugin updates and related functionality.
- * Version:     1.0.6
- * Author:      Zynith SEO
- */
+
 defined('ABSPATH') or exit;
 
 // Define constants for cache


### PR DESCRIPTION
Removing the header comment section of each module will simplify our version management. We definitely don't need to be tracking 40+ versions for one plugin. The main `package.json` version is plenty. This is also the same version that is setup in our main `zynith-seo.php` file programatically. 